### PR TITLE
Extend the writing and waiting functions

### DIFF
--- a/ext/libssh2_ruby_c/channel.c
+++ b/ext/libssh2_ruby_c/channel.c
@@ -168,9 +168,7 @@ channel_read(VALUE self, VALUE buffer_size) {
 static VALUE
 channel_read_ex(VALUE self, VALUE rb_stream_id, VALUE rb_buffer_size) {
     int result;
-    char *buffer;
     int stream_id;
-    long buffer_size;
     LIBSSH2_CHANNEL *channel = get_channel(self);
 
     // Check types
@@ -184,17 +182,12 @@ channel_read_ex(VALUE self, VALUE rb_stream_id, VALUE rb_buffer_size) {
         return Qnil;
     }
 
-    buffer_size = NUM2LONG(rb_buffer_size);
-    if (buffer_size <= 0) {
-        rb_raise(rb_eArgError, "buffer size must be greater than 0");
-        return Qnil;
-    }
-
     // Create our buffer
-    buffer = (char *)malloc(buffer_size);
+    size_t buffer_size = NUM2SIZET(rb_buffer_size);
+    char buffer[buffer_size];
 
     // Read from the channel
-    result = libssh2_channel_read_ex(channel, stream_id, buffer, sizeof(buffer));
+    result = libssh2_channel_read_ex(channel, stream_id, buffer, buffer_size);
 
     if (result > 0) {
         // Read succeeded. Create a string with the correct number of

--- a/ext/libssh2_ruby_c/channel.c
+++ b/ext/libssh2_ruby_c/channel.c
@@ -258,6 +258,22 @@ channel_write_ex(VALUE self, VALUE rb_stream_id, VALUE rb_buffer) {
 
 /*
  * call-seq:
+ *     channel.send_eof -> nil
+ *
+ * Output EOF on the channel to indicate we have no more data to write. In
+ * practice, closes stdin on the remote process.
+ */
+static VALUE
+channel_send_eof(VALUE self) {
+    LIBSSH2_CHANNEL *channel = get_channel(self);
+    int rc = libssh2_channel_send_eof(channel);
+    if (rc != 0)
+        rb_exc_raise(libssh2_ruby_wrap_error(rc));
+    return Qnil;
+}
+
+/*
+ * call-seq:
  *     channel.wait_closed -> true
  *
  * This blocks until the channel receives a CLOSE message from the remote
@@ -281,5 +297,6 @@ void init_libssh2_channel() {
     rb_define_method(cChannel, "read", channel_read, 1);
     rb_define_method(cChannel, "read_ex", channel_read_ex, 2);
     rb_define_method(cChannel, "write_ex", channel_write_ex, 2);
+    rb_define_method(cChannel, "send_eof", channel_send_eof, 0);
     rb_define_method(cChannel, "wait_closed", channel_wait_closed, 0);
 }

--- a/ext/libssh2_ruby_c/channel.c
+++ b/ext/libssh2_ruby_c/channel.c
@@ -229,6 +229,32 @@ channel_read_ex(VALUE self, VALUE rb_stream_id, VALUE rb_buffer_size) {
     }
 }
 
+/*
+ * call-seq:
+ *     channel.write("hello") -> Numeric
+ *
+ * Write data into the specified stream.
+ *
+ * Returns the number of bytes written. The caller must call this function in a
+ * loop to ensure all its data ends up being written.
+ */
+static VALUE
+channel_write_ex(VALUE self, VALUE rb_stream_id, VALUE rb_buffer) {
+    LIBSSH2_CHANNEL *channel = get_channel(self);
+    rb_check_type(rb_stream_id, T_FIXNUM);
+    rb_check_type(rb_buffer, T_STRING);
+
+    ssize_t rc =
+        libssh2_channel_write_ex(channel, NUM2INT(rb_stream_id),
+                                 RSTRING_PTR(rb_buffer), RSTRING_LEN(rb_buffer));
+
+    if (rc < 0) {
+        rb_exc_raise(libssh2_ruby_wrap_error(rc));
+        return Qnil;
+    }
+
+    return SSIZET2NUM(rc);
+}
 
 /*
  * call-seq:
@@ -254,5 +280,6 @@ void init_libssh2_channel() {
     rb_define_method(cChannel, "get_exit_signal", channel_get_exit_signal, 0);
     rb_define_method(cChannel, "read", channel_read, 1);
     rb_define_method(cChannel, "read_ex", channel_read_ex, 2);
+    rb_define_method(cChannel, "write_ex", channel_write_ex, 2);
     rb_define_method(cChannel, "wait_closed", channel_wait_closed, 0);
 }

--- a/lib/libssh2/channel.rb
+++ b/lib/libssh2/channel.rb
@@ -93,6 +93,14 @@ module LibSSH2
     #
     def exit_status = @native_channel.get_exit_status
 
+    # Get the exit signal reported by the remote host. You should only call
+    # this function after {#wait}.
+    #
+    # @return [String] Name of the signal without the leading `SIG`. nil if the
+    #   remote process exited cleanly.
+    #
+    def exit_signal = @native_channel.get_exit_signal
+
     # Attempts reading from specific streams on the channel. This will not
     # block if data is unavailable. This typically doesn't need to be
     # called publicly but can be if you'd like. If data is found, it will

--- a/lib/libssh2/channel.rb
+++ b/lib/libssh2/channel.rb
@@ -86,14 +86,12 @@ module LibSSH2
       @stream_callbacks[STREAM_EXTENDED_DATA] = callback
     end
 
-    # Specify a callback that is called when the exit status is
-    # received on this channel.
+    # Get the exit status reported by the remote host. You should only call
+    # this function after {#wait}.
     #
-    # @yield [exit_status] Called once when the exit status is received with
-    #   the exit status.
-    def on_exit_status(&callback)
-      @stream_callbacks[:exit_status] = callback
-    end
+    # @return [Integer] Exit code, or 0 if not yet available.
+    #
+    def exit_status = @native_channel.get_exit_status
 
     # Attempts reading from specific streams on the channel. This will not
     # block if data is unavailable. This typically doesn't need to be
@@ -150,10 +148,6 @@ module LibSSH2
 
       # Wait for the remote end to close
       @session.blocking_call { @native_channel.wait_closed }
-
-      # Grab our exit status if we care about it
-      exit_status_cb = @stream_callbacks[:exit_status]
-      exit_status_cb.call(@native_channel.get_exit_status) if exit_status_cb
 
       true
     end

--- a/lib/libssh2/channel.rb
+++ b/lib/libssh2/channel.rb
@@ -171,6 +171,12 @@ module LibSSH2
       end
     end
 
+    # Send EOF to indicate we have no more data to {#write}. Closes stdin on
+    # the remote process.
+    def send_eof
+      @session.blocking_call { @native_channel.send_eof }
+    end
+
     protected
 
     # This will read from the given stream ID and call the proper

--- a/lib/libssh2/channel.rb
+++ b/lib/libssh2/channel.rb
@@ -107,8 +107,8 @@ module LibSSH2
       return false if @native_channel.eof
 
       # Attempt to read from stdout/stderr
-      @session.blocking_call { read_stream(STREAM_DATA) }
-      @session.blocking_call { read_stream(STREAM_EXTENDED_DATA) }
+      read_stream(STREAM_DATA)
+      read_stream(STREAM_EXTENDED_DATA)
 
       # Return true always
       true
@@ -123,7 +123,10 @@ module LibSSH2
     # This method will also implicitly call {#close}.
     def wait
       # Read all the data
-      loop { break if !attempt_read }
+      loop do
+        @session.waitsocket
+        break if !attempt_read
+      end
 
       # Close our end, we won't be sending any more requests.
       close if !closed?

--- a/lib/libssh2/channel.rb
+++ b/lib/libssh2/channel.rb
@@ -160,6 +160,17 @@ module LibSSH2
       true
     end
 
+    # Write the given data in the output data stream, which usually maps to
+    # stdin of the remote process.
+    def write(data)
+      until data.empty?
+        written = @session.blocking_call do
+          @native_channel.write_ex(STREAM_DATA, data)
+        end
+        data = data.byteslice(written..)
+      end
+    end
+
     protected
 
     # This will read from the given stream ID and call the proper

--- a/lib/libssh2/session.rb
+++ b/lib/libssh2/session.rb
@@ -127,6 +127,8 @@ module LibSSH2
       continue_conditional = block || Proc.new { !@channels.empty? }
 
       Kernel.loop do
+        waitsocket
+
         # Remove any channels that are closed
         @channels.delete_if { |c| c.closed? }
 


### PR DESCRIPTION
This merge request add new methods for writing data into the standard input of the remote process. It also fixes and extend the wait loops in order not to consume all the CPU like it did, and allows the caller to specify a block to be called at regular intervals instead of losing all the control.